### PR TITLE
New methods implmented, tested with Perl 5.18.2 and Nessus REST API 6.5.4

### DIFF
--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -412,6 +412,17 @@ sub get_scanner_id {
     return $scanner->{id};
 }
 
+sub file_upload {
+    my ($self, %params) = @_;
+
+    croak "missing file name" unless $params{file};
+
+	my $file = delete $params{file};
+
+	my $result = $self->_post_file('/file/upload', $file);
+	return $result;
+}
+
 sub _get {
     my ($self, $path, %params) = @_;
 

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -106,6 +106,19 @@ sub configure_policy {
     return $result;
 }
 
+# Experimental
+sub create_policy {
+    my ($self, %params) = @_;
+
+    croak "missing uuid parameter" unless $params{uuid};
+    croak "missing settings parameter" unless $params{settings};
+
+	my $uuid = delete $params{uuid};
+    my $result = $self->_post("/policies", %params);
+
+    return $result;
+}
+
 sub create_scan {
     my ($self, %params) = @_;
 

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -61,67 +61,6 @@ sub get_policy_id {
     return $policy->{id};
 }
 
-#Bithex 
-sub import_policy {
-    my ($self, %params) = @_;
-
-    croak "missing file name parameter" unless $params{file};
-
-    my $result = $self->_post("/policies/import", %params);
-    return $result;
-}
-
-#Bithex 
-sub get_policy_details {
-    my ($self, %params) = @_;
-
-    croak "missing id parameter" unless $params{id};
-
-	my $policy_id = delete $params{id};
-
-    my $result = $self->_get("/policies/$policy_id");
-    return $result;
-}
-
-#Bithex 
-sub delete_policy {
-    my ($self, %params) = @_;
-
-    croak "missing Policy id parameter" unless $params{id};
-
-	my $policy_id = delete $params{id};
-    my $result = $self->_delete("/policies/$policy_id");
-
-    return $result;
-}
-
-#Bithex 
-sub configure_policy {
-    my ($self, %params) = @_;
-
-    croak "missing id parameter" unless $params{id};
-    croak "missing uuid parameter" unless $params{uuid};
-    croak "missing settings parameter" unless $params{settings};
-
-	my $policy_id = delete $params{id};
-    my $result = $self->_put("/policies/$policy_id", %params);
-
-    return $result;
-}
-
-#Bithex 
-sub create_policy {
-    my ($self, %params) = @_;
-
-    croak "missing uuid parameter" unless $params{uuid};
-    croak "missing settings parameter" unless $params{settings};
-
-	my $uuid = delete $params{uuid};
-    my $result = $self->_post("/policies", %params);
-
-    return $result;
-}
-
 sub create_scan {
     my ($self, %params) = @_;
 
@@ -415,18 +354,6 @@ sub get_scanner_id {
     return $scanner->{id};
 }
 
-#Bithex
-sub file_upload {
-    my ($self, %params) = @_;
-
-    croak "missing file name" unless $params{file};
-
-	my $file = delete $params{file};
-
-	my $result = $self->_post_file('/file/upload', $file);
-	return $result;
-}
-
 sub _get {
     my ($self, $path, %params) = @_;
 
@@ -475,31 +402,6 @@ sub _post {
         $self->{url} . $path,
         'Content-Type' => 'application/json',
         'Content'      => $content
-    );
-
-    my $result = eval { from_json($response->content()) };
-
-    if ($response->is_success()) {
-        return $result;
-    } else {
-        if ($result) {
-            croak "server error: " . $result->{error};
-        } else {
-            croak "communication error: " . $response->message()
-        }
-    }
-}
-
-#Bithex
-sub _post_file {
-    my ($self, $path, $file) = @_;
-
-    my $response = $self->{agent}->post(
-        $self->{url} . $path,
-        'Content-Type' => 'multipart/form-data',
-        'Content'      => [
-			Filedata => [$file]
-		]
     );
 
     my $result = eval { from_json($response->content()) };

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -92,6 +92,20 @@ sub delete_policy {
     return $result;
 }
 
+# Experimental
+sub configure_policy {
+    my ($self, %params) = @_;
+
+    croak "missing id parameter" unless $params{id};
+    croak "missing uuid parameter" unless $params{uuid};
+    croak "missing settings parameter" unless $params{settings};
+
+	my $policy_id = delete $params{id};
+    my $result = $self->_put("/policies/$policy_id", %params);
+
+    return $result;
+}
+
 sub create_scan {
     my ($self, %params) = @_;
 

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -81,6 +81,17 @@ sub get_policy_details {
     return $result;
 }
 
+sub delete_policy {
+    my ($self, %params) = @_;
+
+    croak "missing Policy id parameter" unless $params{id};
+
+	my $policy_id = delete $params{id};
+    my $result = $self->_delete("/policies/$policy_id");
+
+    return $result;
+}
+
 sub create_scan {
     my ($self, %params) = @_;
 

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -70,6 +70,17 @@ sub import_policy {
     return $result;
 }
 
+sub get_policy_details {
+    my ($self, %params) = @_;
+
+    croak "missing id parameter" unless $params{id};
+
+	my $policy_id = delete $params{id};
+
+    my $result = $self->_get("/policies/$policy_id");
+    return $result;
+}
+
 sub create_scan {
     my ($self, %params) = @_;
 

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -61,6 +61,15 @@ sub get_policy_id {
     return $policy->{id};
 }
 
+sub import_policy {
+    my ($self, %params) = @_;
+
+    croak "missing file name parameter" unless $params{id};
+
+    my $result = $self->_post("/policies/import", %params);
+    return $result;
+}
+
 sub create_scan {
     my ($self, %params) = @_;
 
@@ -540,10 +549,10 @@ Returns a reference to a hash with all settings and parameters for a given scan 
 
 See L<https://your.nessus.server:8834/api#/resources/policies/details> for details.
 
-=head2 $nessus->import_policy(file => $fileuploaded)
+=head2 $nessus->import_policy(id => $file_id)
 
 Returns reference to hash with name and identifier of the policy imported.
-NB $fileuploaded must be a valid identifier to a file uploaded to the Nessus server,
+NB $file_id must be a valid identifier to a file uploaded to the Nessus server,
 e.g. with method file_upload()
 
 Example:

--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -486,6 +486,30 @@ sub _post {
     }
 }
 
+sub _post_file {
+    my ($self, $path, $file) = @_;
+
+    my $response = $self->{agent}->post(
+        $self->{url} . $path,
+        'Content-Type' => 'multipart/form-data',
+        'Content'      => [
+			Filedata => [$file]
+		]
+    );
+
+    my $result = eval { from_json($response->content()) };
+
+    if ($response->is_success()) {
+        return $result;
+    } else {
+        if ($result) {
+            croak "server error: " . $result->{error};
+        } else {
+            croak "communication error: " . $response->message()
+        }
+    }
+}
+
 sub _put {
     my ($self, $path, %params) = @_;
 


### PR DESCRIPTION
NB I left a #Bithex comment at top of each method implemented, better take that out before merging.

Best to return the reference to the user, without trying to cast to array.

Implemented new methods:
get_policy_details(id => $policy_id)
import_policy(file => $filename)
delete_policy(id => $policy_id)
file_upload(file => $file)

Implemented internal/private method:
_post_file('/file/upload', $file)

Added documentation for new methods

Implemented new methods:
create_policy(uuid => $template_uuid, settings => $policy_details)
configure_policy(id => $policy_id, uuid => $template_uuid, settings => $policy_details)
which are currently not fully functional with Nessus 6.5.4.
Needs more testing and investigation
