### PR TITLE
Update REST.pm

### DIFF
--- a/lib/Net/Nessus/REST.pm
+++ b/lib/Net/Nessus/REST.pm
@@ -8,7 +8,7 @@ use LWP::UserAgent;
 use JSON;
 use List::Util qw(first);
 
-use version; our $VERSION = version->declare('v0.7.0');
+use version; our $VERSION = version->declare('v0.700.1');
 
 sub new {
     my ($class, %params) = @_;


### PR DESCRIPTION
I think this should fix the version issue, see

http://search.cpan.org/~jpeacock/version-0.9916/lib/version.pod#How_to_convert_a_module_from_decimal_to_dotted-decimal

for more information. Currently 0.6 is seen as the latest version in https://cpan.metacpan.org/modules/02packages.details.txt (and hence in MetaCPAN, Debian etc.
